### PR TITLE
Bug/1471 Cancel adding substance to object

### DIFF
--- a/src/t03/components/optimization/SubstanceEditor.jsx
+++ b/src/t03/components/optimization/SubstanceEditor.jsx
@@ -77,7 +77,6 @@ class SubstanceEditor extends React.Component {
                     result: 0
                 };
             });
-            this.state.addedSubstances.push(substance);
             return this.setState({
                 selectedSubstance: substance
             });
@@ -104,12 +103,19 @@ class SubstanceEditor extends React.Component {
 
     onSaveModal = () => {
         const substance = this.state.selectedSubstance;
+        let substanceHasBeenAdded = false;
+
         const addedSubstances = this.state.addedSubstances.map(s => {
             if(s.id === substance.id) {
+                substanceHasBeenAdded = true;
                 return substance;
             }
             return s;
         });
+
+        if(!substanceHasBeenAdded) {
+            addedSubstances.push(substance);
+        }
 
         this.setState({
             selectedSubstance: null


### PR DESCRIPTION
When adding a substance to an optimization object and cancelling the
modal without saving, it added the substance in the view but not in the
logic.

Resolves: #1471
See also: #1463