### PR TITLE
Feature/1475 Update UI of mt3dms

### DIFF
--- a/src/t03/components/optimization/optimizationConstraints.jsx
+++ b/src/t03/components/optimization/optimizationConstraints.jsx
@@ -138,7 +138,7 @@ class OptimizationConstraintsComponent extends React.Component {
         ];
 
         return (
-            <LayoutComponents.Column heading="Constraints">
+            <LayoutComponents.Column>
                 <Grid style={styles.tablewidth}>
                     <Grid.Row columns={3}>
                         <Grid.Column>

--- a/src/t03/components/optimization/optimizationObjectives.jsx
+++ b/src/t03/components/optimization/optimizationObjectives.jsx
@@ -138,7 +138,7 @@ class OptimizationObjectivesComponent extends React.Component {
         ];
 
         return (
-            <LayoutComponents.Column heading="Objectives">
+            <LayoutComponents.Column>
                 <Grid style={styles.tablewidth}>
                     <Grid.Row columns={3}>
                         <Grid.Column>

--- a/src/t03/components/optimization/optimizationObjects.jsx
+++ b/src/t03/components/optimization/optimizationObjects.jsx
@@ -188,7 +188,7 @@ class OptimizationObjectsComponent extends React.Component {
         }
 
         return (
-            <LayoutComponents.Column heading="Objects">
+            <LayoutComponents.Column>
                 <Grid style={styles.tablewidth}>
                     <Grid.Row columns={3}>
                         <Grid.Column>

--- a/src/t03/components/optimization/optimizationParameters.jsx
+++ b/src/t03/components/optimization/optimizationParameters.jsx
@@ -86,7 +86,7 @@ class OptimizationParametersComponent extends React.Component {
         const {parameters} = this.state;
 
         return (
-            <LayoutComponents.Column heading="Objectives">
+            <LayoutComponents.Column>
                 <Grid style={styles.tablewidth}>
                     <Grid.Row columns={3}>
                         <Grid.Column/>

--- a/src/t03/components/optimization/optimizationResults.jsx
+++ b/src/t03/components/optimization/optimizationResults.jsx
@@ -152,7 +152,7 @@ class OptimizationResultsComponent extends React.Component {
             ? this.state.optimization.progress : null;
 
         return (
-            <LayoutComponents.Column heading="Objectives">
+            <LayoutComponents.Column>
                 <Grid style={styles.tablewidth}>
                     <Grid.Row columns={3}>
                         <Grid.Column>


### PR DESCRIPTION
When making changes is mt3dms, it now shows a message, that the
changes haven't been saved. Pressing the save button, which is on top
of the container now, shows a message, that the changes have been saved.

* Remove headlines from optimization, to fit the transport layout
* Bug fix: clicking on transport now always renders properties

Resolves: #1475