### PR TITLE
Bug/1479 Number inputs are not parsed correctly

### DIFF
--- a/src/core/optimization/OptimizationConstraint.js
+++ b/src/core/optimization/OptimizationConstraint.js
@@ -76,7 +76,7 @@ class OptimizationConstraint {
     }
 
     set value(value) {
-        this._value = parseInt(value, 10);
+        this._value = value ? parseInt(value, 10) : 0;
     }
 
     get operator() {

--- a/src/core/optimization/OptimizationObjective.js
+++ b/src/core/optimization/OptimizationObjective.js
@@ -76,7 +76,7 @@ class OptimizationObjective {
     }
 
     set weight(value) {
-        this._weight = value;
+        this._weight = value ? parseFloat(value) : -1;
     }
 
     get penaltyValue() {
@@ -84,7 +84,7 @@ class OptimizationObjective {
     }
 
     set penaltyValue(value) {
-        this._penaltyValue = value;
+        this._penaltyValue = value ? parseFloat(value) : 999;
     }
 
     get location() {


### PR DESCRIPTION
In optimization objectives and constraints, number inputs are now
parsed correctly.

Resolves: #1479